### PR TITLE
Does not remove prevent-scrolling class with an option

### DIFF
--- a/scripts/dash-modal/view.coffee
+++ b/scripts/dash-modal/view.coffee
@@ -37,7 +37,8 @@ class DashModal.View extends Backbone.View
     @options.onCloseCallback?()
     @$('[data-id=modal]').removeClass('in')
     @$el.hide()
-    $('body').removeClass('prevent-scrolling')
+    unless @options.preventScrollingOnClose
+      $('body').removeClass('prevent-scrolling')
 
   isVisible: ->
     $('body').attr('class') == 'prevent-scrolling'

--- a/spec/dash-modal/view.coffee
+++ b/spec/dash-modal/view.coffee
@@ -17,6 +17,7 @@ describe 'DashModal.View', ->
       onCloseCallback:      options.onCloseCallback
       shouldCloseOnOverlay: options.shouldCloseOnOverlay
       shouldCloseOnEscape:  options.shouldCloseOnEscape
+      preventScrollingOnClose: options.preventScrollingOnClose
       router:               options.router ?= new Backbone.Router()
     modal
 
@@ -154,6 +155,31 @@ describe 'DashModal.View', ->
     modal.show()
 
     expect(modal.$el).toBeVisible()
+
+  it 'adds a class to prevent scrolling when shown', ->
+    template = '<div>Hello</div>'
+    modal = modalView(view: buildView(template)).show()
+
+    expect($('body')).toHaveClass('prevent-scrolling')
+
+  it 'removes the prevent scrolling class when hidden', ->
+    template = '<div>Hello</div>'
+    modal = modalView(view: buildView(template)).show()
+
+    modal.hide()
+
+    expect($('body')).not.toHaveClass('prevent-scrolling')
+
+  it 'does not remove prevent scrolling class with a preventScrollingOnClose option', ->
+    template = '<div>Hello</div>'
+    modal = modalView(
+      view: buildView(template)
+      preventScrollingOnClose: true
+    ).show()
+
+    modal.hide()
+
+    expect($('body')).toHaveClass('prevent-scrolling')
 
   describe "Listening for key events", ->
 


### PR DESCRIPTION
@chandlerroth pointed out that when there are cases when a nested modal is closed, the modal removes a class on the body that prevents scrolling when we actually do not want this class to be removed. 

This PR enables the option to NOT have this class removed on close. 

